### PR TITLE
balance disconnect and daily spend limit

### DIFF
--- a/docs/customer/customer.md
+++ b/docs/customer/customer.md
@@ -100,8 +100,9 @@ By clicking on `+` button we can add customer (see [**Create Customers**](https:
     + **Call Recording Retention Days**: How long the customer wants to keep the recorded calls.
     + **Domain**: You can select the [domain](https://docs.connexcs.com/setup/integrations/portal/#configuration-options) you wish wish to access from the drop-down menu.
     + **Daily Spend Limit**: The maximum limit for a customer for making calls in their chosen currency. Once the limit is reached it won't allow any new calls to connect.
-        !!! note
-            The daily spend day is defined from 00:00 UTC to 00:00 UTC.
+
+    !!! note
+        The daily spend day is defined from 00:00 UTC to 00:00 UTC.
 
 === "Address"
 

--- a/docs/customer/customer.md
+++ b/docs/customer/customer.md
@@ -91,13 +91,17 @@ By clicking on `+` button we can add customer (see [**Create Customers**](https:
     + **Tags**: Use this to add meta-data identifiers to a customer. If a customer routing is created using a template from [**Global Routing**](https://docs.connexcs.com/global-routing/), this will be the tag configured in the template.
     + [**TOML**](https://en.wikipedia.org/wiki/TOML): This is a data storage mechanism for configuration, similar to INI files. It allows you to create advanced customization to set values, etc, for Script Forge to reference later. 
     + **Reseller**: Associate the customer to a preset Reseller Group (see [**Create Groups**](https://docs.connexcs.com/setup/settings/users/#create-groups) for more details.)
+    + **Account Manager**: Designating the control of this account to a specific user.
     + **Invoice Schedule**: Specify frequency for invoice generation. 
     + **Invoice Due Days**: Set the allowed number of days past the due date that the invoice can go unpaid. 
     + **Invoice Template**: Select from a list of existing Templates found in **Setup :material-menu-right: Config :material-menu-right: [Templates](/setup/config/templates/)**
     + **Ext.Accounting ID**: This is used to fill in work an external accounting field to correlate between Connexcs and the external accountancy system.
     + **RTP Firewall**: It will bypass the media Firewall.<br>To let the customer strictly use the existing RTP firewall under **Locked** and its flexibility to use RTP Firewall under **Unlocked**.
-    + **Account Manager**: Designating the control of this account to a specific user.
     + **Call Recording Retention Days**: How long the customer wants to keep the recorded calls.
+    + **Domain**: You can select the [domain](https://docs.connexcs.com/setup/integrations/portal/#configuration-options) you wish wish to access from the drop-down menu.
+    + **Daily Spend Limit**: The maximum limit for a customer for making calls in their chosen currency. Once the limit is reached it won't allow any new calls to connect.
+        !!! note
+            The daily spend day is defined from 00:00 UTC to 00:00 UTC.
 
 === "Address"
 

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -94,6 +94,11 @@ View and configure existing routes on the Routing tab in the Customer card. To c
 
 + **ASR Plus** assists capacity management by helping you define how to handle connections for known failed numbers. For information on the ASR Plus options, see [**ASR Plus Details**](https://docs.connexcs.com/customer/routing/#asr-answer-seizure-ratio-plus-details) below.
 
++ **Balance Disconnect** this feature checks the balance every 60 seconds. It will disconnect the call when the **balance plus the debit limit** is below $0.
+
+  !!! note
+      Balance Disconnect only takes into account the **completed calls**; it excludes any **active calls**.
+
 ### ScriptForge
 
 + **ScriptForge**: Set a custom JavaScript to run from within the ConnexCS platform in-line with the call. Some example operations could be checking a Do Not Call list or forcing a CLI.

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -96,8 +96,8 @@ View and configure existing routes on the Routing tab in the Customer card. To c
 
 + **Balance Disconnect** this feature checks the balance every 60 seconds. It will disconnect the call when the **balance plus the debit limit** is below $0.
 
-  !!! note
-      Balance Disconnect only takes into account the **completed calls**; it excludes any **active calls**.
+!!! note
+    Balance Disconnect only takes into account the **completed calls**; it excludes any **active calls**.
 
 ### ScriptForge
 

--- a/docs/makecall.md
+++ b/docs/makecall.md
@@ -1,0 +1,147 @@
+# Some Interesting Features
+
+## makeCall Feature
+
+When we initiate **makeCall** we pass a number that we're dialing, for example:
+
+```js
+this.makeCall('200')
+this.(res => {
+    res.$on('onStatusChanged', (status)) => {
+        console.log('Auto Status Change', status.session);
+    });
+    console.log('Before Dial');
+})
+.catch (err => {
+    console.log('error, err');
+    console.log('Before Dial');
+});
+```
+
+Then, the **makeCall** features return a **Promise** (an object that represents the eventual completion (or failure) of an asynchronous operation and its resulting value), which results in an **Event Manager** (refers to the process of handling and responding to events that occur in a web page or application).
+
+A **Promise** uses `.then` and `.catch`that enables you to listen to a **Promise**.
+
+You can consider **Event Manager** as a response from the **Promise**.
+
+Thus, when you listen to an event it returns a **Status**. In the above example, the event is `onStatusChanged` and the response you can expect is `status`.
+Thus, whenever the status changes, the **SIP-client** releases the `onStatusChanged` event. The various statuses can be establishing, idle, initial, terminating, etc.
+
+## getProv Feature
+
+It's a feature that works every time you sign-in to the Webphone.
+
+Thus, the Webphone needs to provision a specific user with a set of specific features.
+
+getProv feature return some specific information or **Promise**.
+
+For example, `this.getProv().then` returns the user's provision information such as their user name.
+
+```js
+this.getData().then(async data => {
+      this.getProv().then(prov => { 
+                  data.agentId = prov.sipUser.username;
+```
+
+To sum up we can say, getProv gets data from the servers after provisioning a user.
+
+For example you can get the following information on the Webphone when you use the getProv feature:
+
+```js
+ "prov": {
+        "brandName": "Cacious WebPhone",
+        "menu": [
+            {
+                "id": "home",
+                "title": "Home",
+                "url": "/",
+                "icon": "mdi-home",
+                "order": 1
+            },
+            {
+                "id": "dialpad",
+                "title": "Dialpad",
+                "url": "/dialpad",
+                "icon": "mdi-dialpad",
+                "order": 2
+            },
+            {
+                "id": "agent",
+                "title": "Agent",
+                "url": "/agent",
+                "icon": "mdi-account-tie-voice",
+                "order": 3
+            },
+            {
+                "id": "history",
+                "title": "History",
+                "url": "/call-log",
+                "icon": "mdi-history",
+                "order": 4
+            },
+            {
+                "id": "contacts",
+                "title": "Contacts",
+                "url": "/contacts",
+                "icon": "mdi-card-account-phone",
+                "order": 5
+            },
+            {
+                "id": "settings",
+                "title": "Settings",
+                "url": "/settings",
+                "icon": "mdi-cog",
+                "order": 6
+            }
+        ],
+        "currency": "USD",
+        "flags": [
+            "BALANCE",
+            "EDIT_SETTINGS",
+            "TITLE_USERNAME",
+            "OTP_LOGIN"
+        ],
+        "codec": {
+            "delete": [
+                "opus.*",
+                "pcm.*",
+                "telephone.*",
+                "cn.*",
+                "isac.*"
+            ],
+            "priority": [
+                "red.*"
+            ]
+        },
+        "setup": true,
+        "paymentMethods": {
+            "paypal": {
+                "label": "PayPal",
+                "currencies": [
+                    "USD",
+                    "GBP",
+                    "EUR"
+                ],
+                "min_payment": 0
+            },
+            "stripe": {
+                "label": "Credit Card",
+                "currencies": [
+                    "usd",
+                    "gbp",
+                    "AUD"
+                ],
+                "min_payment": 0,
+                "key": "********"
+            }
+        },
+        "balance": 2045.1765,
+        "sipUser": {
+            "displayName": "cacious",
+            "cli": null,
+            "username": "cacious",
+            "password": "****,
+            "wsServer": "wss://test1.host.connexcs.net",
+            "realm": "test1.host.connexcs.net"
+        },
+```


### PR DESCRIPTION
# 1. Added Balance Disconnect under 

Management > Customer > [Customer Name] > Routing [Ingress] > Capacity Limits > Balance Disconnect 

+ **Balance Disconnect** this feature checks the balance every 60 seconds. It will disconnect the call when the **balance plus the debit limit** is below $0.

  !!! note
      Balance Disconnect only takes into account the **completed calls**; it excludes any **active calls**.


[Ingress Routing - ConnexCS Documentation (bani-2023-7-21--connexcs-docs.netlify.app)](https://bani-2023-7-21--connexcs-docs.netlify.app/customer/routing/#capacity-limits)

# 2. Dialy Spend Limit under 

Customer > + > Config > Daily Spend Limit

 + **Daily Spend Limit**: The maximum limit for a customer for making calls in their chosen currency. Once the limit is reached it won't allow any new calls to connect.
        !!! note
            The daily spend day is defined from 00:00 UTC to 00:00 UTC.
[Customer - ConnexCS Documentation (bani-2023-7-21--connexcs-docs.netlify.app)](https://bani-2023-7-21--connexcs-docs.netlify.app/customer/customer/)