### PR TITLE
Redial Resrtict, RTP Code, ConneXML-timeout in Dial

### DIFF
--- a/docs/class5/connexml.md
+++ b/docs/class5/connexml.md
@@ -325,6 +325,7 @@ An existing call is transferred to a different destination using the `Dial` ver
 |`fromDisplayName`|The fromDisplayName string to be used as the caller id name (SIP From Display Name) presented to the destination. The string should have a maximum of 128 characters, containing only letters, numbers, spaces, and -_~!.+ special characters. If omitted, the display name will be the same as the number in the callerId field|
 |`hangupOnStar`|By tapping the `*` key on their phone, the initial caller can hang up on the called party using the hangupOnStar attribute. It doesn't apply for `Conference` noun|`true`, `false`| `false`|
 |`ringTone`|The ringback tone played back to the caller|`at`,`au`,`bg`,`br`,<br>`be`,`ch`,`cl`,`cn`,`cz`,</br>`de`,`dk`,`ee`,`es`,`fi`,<br>`fr`,`gr`,`hu`,`il`,`in`,<br>`it`,`lt`,`jp`,`mx`,`my`,<br>`nl`,`no`,`nz`,`ph`,`pl`,<br>`pt`,`ru`,`se`,`sg`,<br>`th`,`uk`,`us`,`us-old`,`tw`,<br>`ve`,`za`|`us`|
+|`timeout`|timeout in <Dial> lets you specify the maximum waiting time in seconds for the dialed party to answer|
 
 |**Noun**|**Description**|
 |-------------|----------|
@@ -371,7 +372,15 @@ An existing call is transferred to a different destination using the `Dial` ver
         </Response>
         ```
     
-    5. **Number**
+    5. **timeout**
+        ```xml
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Response>
+            <Dial timeout="60">123456</Dial>
+        </Response>
+        ```
+
+    6. **Number**
         ```xml
         <?xml version="1.0" encoding="UTF-8"?>
         <Response>
@@ -380,7 +389,7 @@ An existing call is transferred to a different destination using the `Dial` ver
             </Dial>
         </Response>"
         ```
-    6. **Queue**
+    7. **Queue**
         ```xml
         <?xml version="1.0" encoding="UTF-8"?>
         <Response>
@@ -390,7 +399,7 @@ An existing call is transferred to a different destination using the `Dial` ver
         </Response>
         ```
 
-    7. **Client**
+    8. **Client**
         ```xml
         <?xml version="1.0" encoding="UTF-8"?>
         <Response>
@@ -399,7 +408,7 @@ An existing call is transferred to a different destination using the `Dial` ver
             </Dial>
         </Response>
         ```
-    8. **Conference**
+    9. **Conference**
         ```xml
         <?xml version="1.0" encoding="UTF-8"?>
         <Response>

--- a/docs/class5/connexml.md
+++ b/docs/class5/connexml.md
@@ -325,7 +325,7 @@ An existing call is transferred to a different destination using the `Dial` ver
 |`fromDisplayName`|The fromDisplayName string to be used as the caller id name (SIP From Display Name) presented to the destination. The string should have a maximum of 128 characters, containing only letters, numbers, spaces, and -_~!.+ special characters. If omitted, the display name will be the same as the number in the callerId field|
 |`hangupOnStar`|By tapping the `*` key on their phone, the initial caller can hang up on the called party using the hangupOnStar attribute. It doesn't apply for `Conference` noun|`true`, `false`| `false`|
 |`ringTone`|The ringback tone played back to the caller|`at`,`au`,`bg`,`br`,<br>`be`,`ch`,`cl`,`cn`,`cz`,</br>`de`,`dk`,`ee`,`es`,`fi`,<br>`fr`,`gr`,`hu`,`il`,`in`,<br>`it`,`lt`,`jp`,`mx`,`my`,<br>`nl`,`no`,`nz`,`ph`,`pl`,<br>`pt`,`ru`,`se`,`sg`,<br>`th`,`uk`,`us`,`us-old`,`tw`,<br>`ve`,`za`|`us`|
-|`timeout`|timeout in <Dial> lets you specify the maximum waiting time in seconds for the dialed party to answer|
+|`timeout`|timeout in <Dial> lets you specify the maximum waiting time in seconds for the dialed party to answer|||
 
 |**Noun**|**Description**|
 |-------------|----------|

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -75,7 +75,6 @@ To enable, click **:material-plus:** next to IP Authentication:
 
     <img src= "/customer/img/codecs.png" width= "600"> 
 
-
 === "Parameter Rewrite"
 
     The **Parameter Rewrite** tab is used to manipulate data as it comes into the system. 
@@ -148,7 +147,7 @@ To enable, click **:material-plus:** next to SIP User Authentication:
         
         :material-menu-right: **`SMPP`**: SMPP, for SMS, is currently not supported.
 
-    + **IP Allow list**: Enter specific IPs or use CIDR notation to specify an entire subnet. 
+    + **IP Allow list**: Enter specific IPs or use CIDR notation to specify an entire subnet.
     + **NAT/SIP Ping**: Set behavior of pings sent from ConnexCS back to the customer through their firewall to their UAC. This helps when there are remote agents connecting to the switch. 
     
         :material-menu-right: **`Disabled`**: No pings are sent
@@ -190,7 +189,6 @@ To enable, click **:material-plus:** next to SIP User Authentication:
 
     <img src= "/customer/img/voicemail.png" width= "600"/>
 ___
-
 
 ### Reset SIP Password
 
@@ -234,7 +232,7 @@ Use `Send` next to the SIP User to send a SIP message to the end device which wi
     Alice->>Bob: BYE
     Bob->>Alice: 200 OK
 ```
-In this case, Bob sends a message to Alice called **OPTIONS** and Alice sends back **200 OK**. If **200 OK** is not sent, the call be get disconnected.
+In this case, Bob sends a message to Alice called **OPTIONS** and Alice sends back **200 OK**. If **200 OK** isn't sent, the call be get disconnected.
 
 **Case 2: Alice Disappears**
 
@@ -261,6 +259,10 @@ In a typical configuration, a packet is sent from the customer UAC out through a
 + Without regular traffic passing between UAS and UAC in the form of keep-alives/registration (a normal occurrence), NAT will eventually time out and shut down the connection.
 + Enabling UDP or SIP pings can show the NAT/firewall that the signaling path is still valid and in use.
 
+!!! Note
+    [Click here](https://cidr.xyz/) to view an interactive IP address and CIDR range visualizer.
+
+
 [ipauth-basic]: /customer/img/ipauth-b.png "Edit Switch Basic"
 [parameter-rewrite]: /customer/img/parameter-rewrite.png "Parameter Rewrite" width="200" height="400"
 [ipauth-adv]: /customer/img/ipauth-adv.png "Edit Switch Advance"
@@ -269,7 +271,3 @@ In a typical configuration, a packet is sent from the customer UAC out through a
 [test-rewrite]: /customer/img/test-rewrite.png "Test Parameter Rewrite"
 [407-trace]: /customer/img/407-trace.png "SIP Trace Error 407"
 [voicemail]: /customer/img/voicemail.png "Voicemail"
-<!--stackedit_data:
-eyJoaXN0b3J5IjpbMTUwMDY4NjkyMCwyNDI4Njg5MDgsLTEzOD
-I0NTQ3NjcsLTE5MjIzMDU2NzBdfQ==
--->

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -26,7 +26,7 @@ To enable, click **:material-plus:** next to IP Authentication:
 
 === "Basic"
 
-    + **IP**: Enter the IP(s) of the customer's switch.<br>**FQDN can be used for Ingress-only switches.**
+    + **IP**: Enter specific IPs or use CIDR notation to specify an entire subnet.<br>**FQDN can be used for Ingress-only switches.**
     + **Switch Direction**: The available options are from the perspective of the customer switch (PBX, dialer, etc), and describe how that switch interacts with the ConnexCS switch. For switches that send and receive calls from ConnexCS, there should be separate entries for each direction. 
         
         :material-menu-right: `Ingress`: This switch *receives* calls from ConnexCS. (Note: When selected, this gives the option of using the FQDN rather than the switch IP.)
@@ -190,6 +190,9 @@ To enable, click **:material-plus:** next to SIP User Authentication:
     <img src= "/customer/img/voicemail.png" width= "600"/>
 ___
 
+!!! Note
+    [Click here](https://cidr.xyz/) to view an interactive IP address and CIDR range visualizer.
+
 ### Reset SIP Password
 
 Click the `Password` key next to the SIP user to reset the password.
@@ -232,6 +235,7 @@ Use `Send` next to the SIP User to send a SIP message to the end device which wi
     Alice->>Bob: BYE
     Bob->>Alice: 200 OK
 ```
+
 In this case, Bob sends a message to Alice called **OPTIONS** and Alice sends back **200 OK**. If **200 OK** isn't sent, the call be get disconnected.
 
 **Case 2: Alice Disappears**
@@ -258,10 +262,6 @@ In a typical configuration, a packet is sent from the customer UAC out through a
 + UDP doesn't send keep-alives (no connected state as with TCP). SIP does maintain a connected state, registration, but may have long periods of inactivity.
 + Without regular traffic passing between UAS and UAC in the form of keep-alives/registration (a normal occurrence), NAT will eventually time out and shut down the connection.
 + Enabling UDP or SIP pings can show the NAT/firewall that the signaling path is still valid and in use.
-
-!!! Note
-    [Click here](https://cidr.xyz/) to view an interactive IP address and CIDR range visualizer.
-
 
 [ipauth-basic]: /customer/img/ipauth-b.png "Edit Switch Basic"
 [parameter-rewrite]: /customer/img/parameter-rewrite.png "Parameter Rewrite" width="200" height="400"

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -38,6 +38,9 @@ To enable, click **:material-plus:** next to IP Authentication:
     
         ![alt text][ipauth-basic]
 
+!!! Note
+    [Click here](https://cidr.xyz/) to view an interactive IP address and CIDR range visualizer.
+
 === "Advanced"
 
     + **Manufacturer and Version**: These references fields allow you to enter the customer switch Manufacturer and Version, if required (these fields are not functional; they are informational only).
@@ -189,9 +192,6 @@ To enable, click **:material-plus:** next to SIP User Authentication:
 
     <img src= "/customer/img/voicemail.png" width= "600"/>
 ___
-
-!!! Note
-    [Click here](https://cidr.xyz/) to view an interactive IP address and CIDR range visualizer.
 
 ### Reset SIP Password
 

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -116,7 +116,7 @@ Used for troubleshooting, you can remove carriers from a route and run a quick t
 
 + **Lock** (Allow): One or more rate cards from the list of available providers.
 + **Exclude** (Deny): Exclude access to one or more rate cards in the list of available providers.
-+ **Redial Max Count**: This a smart limitation feature which allow the carrier to restrict the maximum number of times their customers can redial in a selected time frame which is **Redial Max Period**. For example, you select 5 for this field, it means your customer can dial only 5 times.
++ **Redial Max Count**: This a smart limitation feature that allows the carrier to restrict the maximum number of times their customers can redial. After reaching this limit, customers must wait for a certain amount of time defined by the **Redial Max Period**. For example, you select 5 for this field, it means your customer can dial only 5 times.
 + **Redial Max Period**: Select the time-period for which you can allow the customer to redial. For example, if you select Redial Max Count as 10 and Redial Max Period as 6000 seconds, this means your customer can redial maximum 10 times within 6000 seconds.
 + **DNC (Do Not Call) List**: The customer won't be able to able to dial the numbers in the specified DNC list. You can add the list of numbers in the [**Database**](https://docs.connexcs.com/developers/database/).
 
@@ -261,7 +261,7 @@ An extra charge per recorded call of $0.003 gets added to existing fees or charg
 
         |Input/Offering side|Mask|Transcode|Output/Outgoing Offer|Explanation|
         |-------------------|-----|---------|--------------------|-----------|
-        |G729A|G729A|Opus|Opus|Transcoding happens between G729A and Opus but output is Opus, G729 is filtered out|
+        |G729A|G729A|Opus|Opus|Transcoding happens between G729A and Opus but output is Opus, G729A is filtered out from outgoing offer|
         |G729A||Opus|G729A and Opus| Transcoding happens between G729A and Opus but outputs are both Opus and G729A since G729A wasn't filtered out|
 
          + **Accept**: This option is similar to **Strip** and **Mask** but it isn't removed from the codecs offered list. When you select this option, the selected codec is offered to the remote peer (output/outgoing offer), if the remote peer rejects the offered (incoming) codec it will be used for transcoding and is accepted by the input/offering side.

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -130,6 +130,18 @@ Used for troubleshooting, you can remove carriers from a route and run a quick t
 !!! tip "Exclude Use Case"
     If a customer reports an issue with a carrier or route, you can come here and set the carrier / route to Exclude and **`Save`**, then come back and remove it, and do a **`Delay and Save`** for a later date.
 
+!!! Example "Example: Redial Max Count and Redial Max Period"
+    For example, if you have set Redial Max Count (maximum redials in a given time period) as 4 and Redial Max Period as 24 hours for your customer, then your customer can **resume redialling after 24 hours after the last call "starts"/last call was placed**.
+    For instance, 4 Redials in 24 hours (Time starts from 9:00 AM)
+    |Redial number  |Time    |
+    |---------------|--------|
+    |Redial number 1|10:00 AM|
+    |Redial number 2|01:00 PM|
+    |Redial number 3|04:00 PM|
+    |Redial number 4|08:00 PM|
+
+    The last(4<sup>th</sup> call) redial call was placed at 08:00 PM, so the customer can start redialing at 08:00 PM the next day.
+
 ### Media
 
 + **Transcoding**: Enter the number  of channels allowed for transcoding. This is a limited option. The best use case is for customers in low-bandwidth areas that want to use G.729.

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -133,6 +133,7 @@ Used for troubleshooting, you can remove carriers from a route and run a quick t
 !!! Example "Example: Redial Max Count and Redial Max Period"
     For example, if you have set Redial Max Count (maximum redials in a given time period) as 4 and Redial Max Period as 24 hours for your customer, then your customer can **resume redialling after 24 hours after the last call "starts"/last call was placed**.
     For instance, 4 Redials in 24 hours (Time starts from 9:00 AM)
+
     |Redial number  |Time    |
     |---------------|--------|
     |Redial number 1|10:00 AM|

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -116,7 +116,7 @@ Used for troubleshooting, you can remove carriers from a route and run a quick t
 
 + **Lock** (Allow): One or more rate cards from the list of available providers.
 + **Exclude** (Deny): Exclude access to one or more rate cards in the list of available providers.
-+ + **Redial Max Count**: This a smart limitation feature which allow the carrier to restrict the maximum number of times their customers can redial in a selected time frame which is **Redial Max Period**. For example, you select 5 for this field, it means your customer can dial only 5 times.
++ **Redial Max Count**: This a smart limitation feature which allow the carrier to restrict the maximum number of times their customers can redial in a selected time frame which is **Redial Max Period**. For example, you select 5 for this field, it means your customer can dial only 5 times.
 + **Redial Max Period**: Select the time-period for which you can allow the customer to redial. For example, if you select Redial Max Count as 10 and Redial Max Period as 6000 seconds, this means your customer can redial maximum 10 times within 6000 seconds.
 + **DNC (Do Not Call) List**: The customer won't be able to able to dial the numbers in the specified DNC list. You can add the list of numbers in the [**Database**](https://docs.connexcs.com/developers/database/).
 
@@ -234,30 +234,31 @@ An extra charge per recorded call of $0.003 gets added to existing fees or charg
 + **RTP Codec**: This fields allows you to have more specific control over the Codecs you choose for your system. After the selection you can assign various **Permissions** to the Codecs you select.
 
     + **Types of Permissions include**:
-      +  **Except**: This permission allows you to block all the codecs apart from the ones in the Whitelist. Codecs that were not included in the carrier's initial codec list will not be taken into consideration.
-      +  **Offer**: Offer also blocks the codecs apart from the ones in the whitelist and provides flexibility to change the order of the codecs in the list as well. Thus, the first codec in the list is treated as the primary codec (at the output) even if it was the last codec in the list.
-      +  **Consume**: Identical to mask but enables the transcoding engine even if no other transcoding related options are given.
-      +  **Transcode**: Allows the addition of codecs in the offered codec list even if the codecs were not included in the original list of codecs. Here, transcoding engine will be engaged meaning  behind-the-scenes translation process is happening to ensure communication.<br> You can only add those those codecs which are supported by your device for both encoding and decoding process. <br>One limitation of using this option is that it will strip-off all the unsupported codecs. Note that using this option doesn't necessarily always engage the transcoding engine. If all codecs given in the transcode list were present in the original list of offered codecs, then no transcoding will be done.<br> When you use this permission it enables you to mark/modify the Ptime.
-      +  **Strip**: This permission allows you to remove the selected codecs or RTP Payload types from the SDP. Codecs removed using this option behaves as if they never existed in the SDP.
+        + **Except**: This permission allows you to block all the codecs apart from the ones in the Whitelist. Codecs that were not included in the carrier's initial codec list will not be taken into consideration.
+        +  **Offer**: Offer also blocks the codecs apart from the ones in the whitelist and provides flexibility to change the order of the codecs in the list as well. Thus, the first codec in the list is treated as the primary codec (at the output) even if it was the last codec in the list.
+        +  **Consume**: Identical to mask but enables the transcoding engine even if no other transcoding related options are given.
+        +  **Transcode**: Allows the addition of codecs in the offered codec list even if the codecs were not included in the original list of codecs. Here, transcoding engine will be engaged meaning  behind-the-scenes translation process is happening to ensure communication.<br> You can only add those those codecs which are supported by your device for both encoding and decoding process. <br>One limitation of using this option is that it will strip-off all the unsupported codecs. Note that using this option doesn't necessarily always engage the transcoding engine. If all codecs given in the transcode list were present in the original list of offered codecs, then no transcoding will be done.<br> When you use this permission it enables you to mark/modify the Ptime.
+        +  **Strip**: This permission allows you to remove the selected codecs or RTP Payload types from the SDP. Codecs removed using this option behaves as if they never existed in the SDP.
   
-      |Strip|Transcode|Explanation|
-      |-----|---------|-----------|
-      |G729A|Opus|G729A is unavailable for transcoding|
-      +  **Mask**: This option allows you to filter-out the selected codec from the output. Mask works well in combination with **Transcode** option. For example,
+        |Strip|Transcode|Explanation|
+        |-----|---------|-----------|
+        |G729A|Opus|G729A is unavailable for transcoding|
+        
+        +  **Mask**: This option allows you to filter-out the selected codec from the output. Mask works well in combination with **Transcode** option. For example,
 
-      |Input/Offering side|Mask|Transcode|Output/Outgoing Offer|Explanation|
-      |-------------------|-----|---------|--------------------|-----------|
-      |G729A|G729A|Opus|Opus|Transcoding happens between G729A and Opus but output is Opus, G729 is filtered out|
-      |G729A||Opus|G729A and Opus| Transcoding happens between G729A and Opus but outputs are both Opus and G729A since G729A wasn't filtered out|
+        |Input/Offering side|Mask|Transcode|Output/Outgoing Offer|Explanation|
+        |-------------------|-----|---------|--------------------|-----------|
+        |G729A|G729A|Opus|Opus|Transcoding happens between G729A and Opus but output is Opus, G729 is filtered out|
+        |G729A||Opus|G729A and Opus| Transcoding happens between G729A and Opus but outputs are both Opus and G729A since G729A wasn't filtered out|
 
-       + **Accept**: This option is similar to **Strip** and **Mask** but it isn't removed from the codecs offered list. When you select this option, the selected codec is offered to the remote peer (output/outgoing offer), if the remote peer rejects the offered (incoming) codec it will be used for transcoding and is accepted by the input/offering side.
-       In short, Accept permission allows your device to use codecs offered by the remote peer even if they weren't your initial choice.
+         + **Accept**: This option is similar to **Strip** and **Mask** but it isn't removed from the codecs offered list. When you select this option, the selected codec is offered to the remote peer (output/outgoing offer), if the remote peer rejects the offered (incoming) codec it will be used for transcoding and is accepted by the input/offering side.
+        In short, Accept permission allows your device to use codecs offered by the remote peer even if they weren't your initial choice.
 
-      |Input/Offering side|Accept|Transcode|Output/Outgoing Offer|Explanation|
-      |-------------------|------|---------|---------------------|-----------|
-      |G729A|G729A|Opus|Reject|Transcoding still happens between G729A and Opus|
+        |Input/Offering side|Accept|Transcode|Output/Outgoing Offer|Explanation|
+        |-------------------|------|---------|---------------------|-----------|
+        |G729A|G729A|Opus|Reject|Transcoding still happens between G729A and Opus|
 
-+ **Ptime(ms)**: This value determines the length of time each box (RTP packet) can hold. A higher ptime means each packet carries a longer chunk of audio/video data (bigger box), while a lower ptime means shorter chunks (smaller boxes).
+    + **Ptime(ms)**: This value determines the length of time each box (RTP packet) can hold. A higher ptime means each packet carries a longer chunk of audio/video data (bigger box), while a lower ptime means shorter chunks (smaller boxes).
 
 ### Strategy
 

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -116,6 +116,8 @@ Used for troubleshooting, you can remove carriers from a route and run a quick t
 
 + **Lock** (Allow): One or more rate cards from the list of available providers.
 + **Exclude** (Deny): Exclude access to one or more rate cards in the list of available providers.
++ + **Redial Max Count**: This a smart limitation feature which allow the carrier to restrict the maximum number of times their customers can redial in a selected time frame which is **Redial Max Period**. For example, you select 5 for this field, it means your customer can dial only 5 times.
++ **Redial Max Period**: Select the time-period for which you can allow the customer to redial. For example, if you select Redial Max Count as 10 and Redial Max Period as 6000 seconds, this means your customer can redial maximum 10 times within 6000 seconds.
 + **DNC (Do Not Call) List**: The customer won't be able to able to dial the numbers in the specified DNC list. You can add the list of numbers in the [**Database**](https://docs.connexcs.com/developers/database/).
 
     Apart from your own DNC list you can also choose [**United States Federal DNC**](https://www.donotcall.gov/). Choosing not to accept telemarketing calls is possible because of the National Do Not Call Registry.
@@ -228,6 +230,34 @@ An extra charge per recorded call of $0.003 gets added to existing fees or charg
 + **Block DTMF:** This option allows you to either `pass` or `block` DTMF through your calls.
 
 !!! note "Make sure your carrier supports the DTMF feature."
+
++ **RTP Codec**: This fields allows you to have more specific control over the Codecs you choose for your system. After the selection you can assign various **Permissions** to the Codecs you select.
+
+    + **Types of Permissions include**:
+      +  **Except**: This permission allows you to block all the codecs apart from the ones in the Whitelist. Codecs that were not included in the carrier's initial codec list will not be taken into consideration.
+      +  **Offer**: Offer also blocks the codecs apart from the ones in the whitelist and provides flexibility to change the order of the codecs in the list as well. Thus, the first codec in the list is treated as the primary codec (at the output) even if it was the last codec in the list.
+      +  **Consume**: Identical to mask but enables the transcoding engine even if no other transcoding related options are given.
+      +  **Transcode**: Allows the addition of codecs in the offered codec list even if the codecs were not included in the original list of codecs. Here, transcoding engine will be engaged meaning  behind-the-scenes translation process is happening to ensure communication.<br> You can only add those those codecs which are supported by your device for both encoding and decoding process. <br>One limitation of using this option is that it will strip-off all the unsupported codecs. Note that using this option doesn't necessarily always engage the transcoding engine. If all codecs given in the transcode list were present in the original list of offered codecs, then no transcoding will be done.<br> When you use this permission it enables you to mark/modify the Ptime.
+      +  **Strip**: This permission allows you to remove the selected codecs or RTP Payload types from the SDP. Codecs removed using this option behaves as if they never existed in the SDP.
+  
+      |Strip|Transcode|Explanation|
+      |-----|---------|-----------|
+      |G729A|Opus|G729A is unavailable for transcoding|
+      +  **Mask**: This option allows you to filter-out the selected codec from the output. Mask works well in combination with **Transcode** option. For example,
+
+      |Input/Offering side|Mask|Transcode|Output/Outgoing Offer|Explanation|
+      |-------------------|-----|---------|--------------------|-----------|
+      |G729A|G729A|Opus|Opus|Transcoding happens between G729A and Opus but output is Opus, G729 is filtered out|
+      |G729A||Opus|G729A and Opus| Transcoding happens between G729A and Opus but outputs are both Opus and G729A since G729A wasn't filtered out|
+
+       + **Accept**: This option is similar to **Strip** and **Mask** but it isn't removed from the codecs offered list. When you select this option, the selected codec is offered to the remote peer (output/outgoing offer), if the remote peer rejects the offered (incoming) codec it will be used for transcoding and is accepted by the input/offering side.
+       In short, Accept permission allows your device to use codecs offered by the remote peer even if they weren't your initial choice.
+
+      |Input/Offering side|Accept|Transcode|Output/Outgoing Offer|Explanation|
+      |-------------------|------|---------|---------------------|-----------|
+      |G729A|G729A|Opus|Reject|Transcoding still happens between G729A and Opus|
+
++ **Ptime(ms)**: This value determines the length of time each box (RTP packet) can hold. A higher ptime means each packet carries a longer chunk of audio/video data (bigger box), while a lower ptime means shorter chunks (smaller boxes).
 
 ### Strategy
 

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -27,7 +27,7 @@ View and configure existing routes on the Routing tab in the Customer card. To c
     + **Extension**: (uses SIP users in Customer :material-menu-right: Auth configured SIP Users) Send a call to a Session Initiation Protocol (SIP) Authenticated user on the account.
     + **Customer IP**: (uses IPs in Customer :material-menu-right: Authconfigured IPs) Send a call from an agent back to the customer's Private Branch eXchange (PBX), using either the Tech Prefix (e.g.: #9) or a Dial String (e.g.: `^[0-9](4)$`).
     + **To Carriers**: Choose a carrier to send the call to a location outside of the ConnexCS system.
-   
+
 + **Tech Prefix**: This lets you distinguish a route from an inbound party.
   When several customers share the same IP address, each customer needs an individual Tech Prefix so the switch can route calls correctly.
   It enables service providers to differentiate between several rate cards.
@@ -117,7 +117,7 @@ Used for troubleshooting, you can remove carriers from a route and run a quick t
 + **Lock** (Allow): One or more rate cards from the list of available providers.
 + **Exclude** (Deny): Exclude access to one or more rate cards in the list of available providers.
 + **Redial Max Count**: This a smart limitation feature that allows the carrier to restrict the maximum number of times their customers can redial. After reaching this limit, customers must wait for a certain amount of time defined by the **Redial Max Period**. For example, you select 5 for this field, it means your customer can dial only 5 times.
-+ **Redial Max Period**: Select the time-period for which you can allow the customer to redial. For example, if you select Redial Max Count as 10 and Redial Max Period as 6000 seconds, this means your customer can redial maximum 10 times within 6000 seconds.
++ **Redial Max Period**: It refers to the duration of time during which a customer is restricted from making further redial attempts to the same number after reaching the maximum redial count.
 + **DNC (Do Not Call) List**: The customer won't be able to able to dial the numbers in the specified DNC list. You can add the list of numbers in the [**Database**](https://docs.connexcs.com/developers/database/).
 
     Apart from your own DNC list you can also choose [**United States Federal DNC**](https://www.donotcall.gov/). Choosing not to accept telemarketing calls is possible because of the National Do Not Call Registry.
@@ -247,16 +247,16 @@ An extra charge per recorded call of $0.003 gets added to existing fees or charg
 + **RTP Codec**: This fields allows you to have more specific control over the Codecs you choose for your system. After the selection you can assign various **Permissions** to the Codecs you select.
 
     + **Types of Permissions include**:
-        + **Except**: This permission allows you to block all the codecs apart from the ones in the Whitelist. Codecs that were not included in the carrier's initial codec list will not be taken into consideration.
+        + **Except**: This permission allows you to block all the codecs apart from the ones in the Whitelist. Codecs that weren't included in the carrier's initial codec list won't be taken into consideration.
         +  **Offer**: Offer also blocks the codecs apart from the ones in the whitelist and provides flexibility to change the order of the codecs in the list as well. Thus, the first codec in the list is treated as the primary codec (at the output) even if it was the last codec in the list.
         +  **Consume**: Identical to mask but enables the transcoding engine even if no other transcoding related options are given.
-        +  **Transcode**: Allows the addition of codecs in the offered codec list even if the codecs were not included in the original list of codecs. Here, transcoding engine will be engaged meaning  behind-the-scenes translation process is happening to ensure communication.<br> You can only add those those codecs which are supported by your device for both encoding and decoding process. <br>One limitation of using this option is that it will strip-off all the unsupported codecs. Note that using this option doesn't necessarily always engage the transcoding engine. If all codecs given in the transcode list were present in the original list of offered codecs, then no transcoding will be done.<br> When you use this permission it enables you to mark/modify the Ptime.
+        +  **Transcode**: Allows the addition of codecs in the offered codec list even if the codecs weren't included in the original list of codecs. Here, transcoding engine will be engaged meaning  behind-the-scenes translation process is happening to ensure communication.<br> You can only add those codecs which are supported by your device for both encoding and decoding process. <br>One limitation of using this option is that it will strip-off all the unsupported codecs. Note that using this option doesn't necessarily always engage the transcoding engine. If all codecs given in the transcode list were present in the original list of offered codecs, then no transcoding will be done.<br> When you use this permission it enables you to mark/modify the Ptime.
         +  **Strip**: This permission allows you to remove the selected codecs or RTP Payload types from the SDP. Codecs removed using this option behaves as if they never existed in the SDP.
   
         |Strip|Transcode|Explanation|
         |-----|---------|-----------|
         |G729A|Opus|G729A is unavailable for transcoding|
-        
+
         +  **Mask**: This option allows you to filter-out the selected codec from the output. Mask works well in combination with **Transcode** option. For example,
 
         |Input/Offering side|Mask|Transcode|Output/Outgoing Offer|Explanation|

--- a/docs/guides/stir-shaken-fcc.md
+++ b/docs/guides/stir-shaken-fcc.md
@@ -196,7 +196,7 @@ The TRACED Act specified that Service Providers must "no later than June 30 2021
 Complete the [**Service Provider SHAKEN STI-PA Registration**](https://authenticate.iconectiv.com/service-provider-authenticate) after you have completed the preceding three procedures.
 
 !!! Note
-    [Click here](https://test-shaken.sansay.cloud) to test your Stir-Shaken. 
+    [Click here](https://test-shaken.sansay.cloud) to test your Stir-Shaken.
 
 ## FAQ
 
@@ -212,11 +212,9 @@ For providers with less than 100k lines, you have options:
 + SHAKEN or Robocall Mitigation for SIP
 + Robocall mitigation for TDM interconnects
 
-
 **Question:** How does this impact calls originating from outside the US?
 
 This only applies to US calling numbers, even if the carrier is outside of the US. If calls are originating outside the US with non-US numbers, none of this applies. Its required that US carriers drop calls received from US numbers that aren't verified for SHAKEN.
-
 
 **Question:** Does ConnexCS provide SHAKEN?
 

--- a/docs/guides/stir-shaken-fcc.md
+++ b/docs/guides/stir-shaken-fcc.md
@@ -6,7 +6,7 @@ In recent years, **Illegal Robocalling** is one of the most problematic activiti
 
 With 4.6 billion robocalls a month in the U.S. alone, this activity impacts everyone in different ways:
 
-1. Estimated value of Lost time from unwanted Robocalls for customers and consumers is around $3 billion / year. It does not include losses related to fraud.
+1. Estimated value of Lost time from unwanted Robocalls for customers and consumers is around $3 billion / year. It doesn't include losses related to fraud.
 2. Service providers are handling and manage constant service calls from customers. It also manages the extra traffic on the networks.
 3. Businesses can't reach customers, since no one wants to answer the phone.
 
@@ -19,7 +19,7 @@ Legitimate examples of a robocall would be from:
     + Telephone campaigns (telemarketing or political)
     + Public-service (from your child's school)
     + Emergency announcements (Amber Alert or Weather Advisory)
-            
+
 When robocalling uses spoofed numbers or illegal methods to reach end users, considered as illegal. Examples include bypassing Do Not Call lists. These calls are typically associated with some sort of added fraud or scam.
 
 ## TRACED Act
@@ -154,7 +154,6 @@ Service Provider must have **Service Provider Code (SPC)** token from the **STI-
 
 !!! Warning
     Once you receive the certs, you can still revoke them if Service Providers misbehave.
->>>>>>> d2e94be7ce5d9e7aeedf9b0f8439763e06f65700
 
 ## Voice Service Providers implementation
 
@@ -178,7 +177,6 @@ FCC doesn't have any specific instructions or recommendations, but they have pro
 + It must be public and transparent.
 + Providers must cooperate with the [**US Telecom Traceback Group**](https://www.ustelecom.org/the-industry-traceback-group-itg/) to produce requested Call Detail Records on time.
 
-
 ### SHAKEN for Time Division Multiplexing
 
 **TDM (Time Division Multiplexing)** is no longer commonly found at the edge of telephony networks, but is still in use in the core of telephony networks. If not accounted for, then all the meticulously gather and certified SIP SHAKEN info gets lost when it hits TDM segments.
@@ -197,7 +195,8 @@ The TRACED Act specified that Service Providers must "no later than June 30 2021
 
 Complete the [**Service Provider SHAKEN STI-PA Registration**](https://authenticate.iconectiv.com/service-provider-authenticate) after you have completed the preceding three procedures.
 
-
+!!! Note
+    [Click here](https://test-shaken.sansay.cloud) to test your Stir-Shaken. 
 
 ## FAQ
 

--- a/docs/setup/advanced/rtp-block.md
+++ b/docs/setup/advanced/rtp-block.md
@@ -18,7 +18,7 @@ This feature is also known as **Block Media IP**. In simple terms, it enables yo
 
 5. After the settings have been saved, you may check the **Status** in **Logging**.
 
-<img src= "/setup/img/rtp11.png" width= "250">
+<img src= "/setup/img/rtp11.png" width= "400">
 
 !!! Note
     [Click here](https://cidr.xyz/) to view an interactive IP address and CIDR range visualizer.

--- a/docs/setup/advanced/rtp-block.md
+++ b/docs/setup/advanced/rtp-block.md
@@ -12,10 +12,13 @@ This feature is also known as **Block Media IP**. In simple terms, it enables yo
 
 2. Enter the IP address in the [CIDR (Classless Inter-Domain Routing)](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) field you wish to block..![rtp2](/setup/img/rtp2.jpg) For example, if you are using a single IP address you may use 11.12.131.90/34 format.
 
-3. If that IP address exists in the RTP section and the call contains the IP adress in the SDP section, then the call will be blocked. You will be able to see the SDP section in the **INVITE** header in the **SIP Trace**.
+3. If that IP address exists in the RTP section and the call contains the IP address in the SDP section, then the call will be blocked. You will be able to see the SDP section in the **INVITE** header in the **SIP Trace**.
 
 4. Click on `Save` button.
 
 5. After the settings have been saved, you may check the **Status** in **Logging**.
 
-<img src= "/setup/img/rtp11/png" width= "250">
+<img src= "/setup/img/rtp11.png" width= "250">
+
+!!! Note
+    [Click here](https://cidr.xyz/) to view an interactive IP address and CIDR range visualizer.

--- a/docs/setup/advanced/rtp-block.md
+++ b/docs/setup/advanced/rtp-block.md
@@ -12,7 +12,7 @@ This feature is also known as **Block Media IP**. In simple terms, it enables yo
 
 2. Enter the IP address in the [CIDR (Classless Inter-Domain Routing)](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) field you wish to block..![rtp2](/setup/img/rtp2.jpg) For example, if you are using a single IP address you may use 11.12.131.90/34 format.
 
-3. If that IP address exists in the RTP section and the call contains the IP address in the SDP section, then the call will be blocked. You will be able to see the SDP section in the **INVITE** header in the **SIP Trace**.
+3. If that IP address exists in the RTP block section and the call contains the IP address in the SDP section, then the call will be blocked. You will be able to see the SDP section in the **INVITE** header in the **SIP Trace**.
 
 4. Click on `Save` button.
 

--- a/docs/setup/information/stir-shaken.md
+++ b/docs/setup/information/stir-shaken.md
@@ -21,6 +21,9 @@ Once you have the certificate, it's added to ConnexCS as described in the steps 
 !!! info "STIR/SHAKEN background"
     See Wikipedia [**STIR / SHAKEN**](https://en.wikipedia.org/wiki/STIR/SHAKEN) and the FCC [**Report on Selection of Governance Authority and Timely Deployment of SHAKEN/STIR**](https://docs.fcc.gov/public/attachments/DOC-350542A1.pdf) for details.
 
+!!! Note
+    [Click here](https://test-shaken.sansay.cloud) to test your Stir-Shaken.
+
 ## Add STIR / SHAKEN Cert
 
 To add a certificate:
@@ -32,6 +35,3 @@ To add a certificate:
 &emsp;![alt text][stirshaken]
 
 [stirshaken]: /setup/img/stirshaken.png "Add Stir-Shaken Cert"
-<!--stackedit_data:
-eyJoaXN0b3J5IjpbLTEzNTQzODMyMDddfQ==
--->

--- a/docs/setup/settings/users.md
+++ b/docs/setup/settings/users.md
@@ -54,6 +54,9 @@ After entering the information, click **`Save`**.
 
 &emsp;![alt text][user]
 
+!!! Note
+    [Click here](https://cidr.xyz/) to view an interactive IP address and CIDR range visualizer.
+
 !!! question "Why should you specify an email address that you use often?"
 
     * The email address is the username to log into the user account.


### PR DESCRIPTION
# 1. Routing > Locks > Redial max count and redial max period

+ **Redial Max Count**: This a smart limitation feature which allow the carrier to restrict the maximum number of times their customers can redial in a selected time frame which is **Redial Max Period**. For example, you select 5 for this field, it means your customer can dial only 5 times.
+ **Redial Max Period**: Select the time-period for which you can allow the customer to redial. For example, if you select Redial Max Count as 10 and Redial Max Period as 6000 seconds, this means your customer can redial maximum 10 times within 6000 seconds.

!!! Example "Example: Redial Max Count and Redial Max Period"
    For example, if you have set Redial Max Count (maximum redials in a given time period) as 4 and Redial Max Period as 24 hours for your customer, then your customer can **resume redialling after 24 hours after the last call "starts"/last call was placed**.
    For instance, 4 Redials in 24 hours (Time starts from 9:00 AM)
    |Redial number  |Time    |
    |---------------|--------|
    |Redial number 1|10:00 AM|
    |Redial number 2|01:00 PM|
    |Redial number 3|04:00 PM|
    |Redial number 4|08:00 PM|

    The last(4<sup>th</sup> call) redial call was placed at 08:00 PM, so the customer can start redialing at 08:00 PM the next day.

[Ingress Routing - ConnexCS Documentation (bani-redial--connexcs-docs.netlify.app)](https://bani-redial--connexcs-docs.netlify.app/customer/routing/#locks)

# 2. RTP Codec : Customer > Routing > Media

+ **RTP Codec**: This fields allows you to have more specific control over the Codecs you choose for your system. After the selection you can assign various **Permissions** to the Codecs you select.

    + **Types of Permissions include**:
      +  **Except**: This permission allows you to block all the codecs apart from the ones in the Whitelist. Codecs that were not included in the carrier's initial codec list will not be taken into consideration.
      +  **Offer**: Offer also blocks the codecs apart from the ones in the whitelist and provides flexibility to change the order of the codecs in the list as well. Thus, the first codec in the list is treated as the primary codec (at the output) even if it was the last codec in the list.
      +  **Consume**: Identical to mask but enables the transcoding engine even if no other transcoding related options are given.
      +  **Transcode**: Allows the addition of codecs in the offered codec list even if the codecs were not included in the original list of codecs. Here, transcoding engine will be engaged meaning  behind-the-scenes translation process is happening to ensure communication.<br> You can only add those those codecs which are supported by your device for both encoding and decoding process. <br>One limitation of using this option is that it will strip-off all the unsupported codecs. Note that using this option doesn't necessarily always engage the transcoding engine. If all codecs given in the transcode list were present in the original list of offered codecs, then no transcoding will be done.<br> When you use this permission it enables you to mark/modify the Ptime.
      +  **Strip**: This permission allows you to remove the selected codecs or RTP Payload types from the SDP. Codecs removed using this option behaves as if they never existed in the SDP.
  
      |Strip|Transcode|Explanation|
      |-----|---------|-----------|
      |G729A|Opus|G729A is unavailable for transcoding|
      +  **Mask**: This option allows you to filter-out the selected codec from the output. Mask works well in combination with **Transcode** option. For example,

      |Input/Offering side|Mask|Transcode|Output/Outgoing Offer|Explanation|
      |-------------------|-----|---------|--------------------|-----------|
      |G729A|G729A|Opus|Opus|Transcoding happens between G729A and Opus but output is Opus, G729 is filtered out|
      |G729A||Opus|G729A and Opus| Transcoding happens between G729A and Opus but outputs are both Opus and G729A since G729A wasn't filtered out|

       + **Accept**: This option is similar to **Strip** and **Mask** but it isn't removed from the codecs offered list. When you select this option, the selected codec is offered to the remote peer (output/outgoing offer), if the remote peer rejects the offered (incoming) codec it will be used for transcoding and is accepted by the input/offering side.
       In short, Accept permission allows your device to use codecs offered by the remote peer even if they weren't your initial choice.

      |Input/Offering side|Accept|Transcode|Output/Outgoing Offer|Explanation|
      |-------------------|------|---------|---------------------|-----------|
      |G729A|G729A|Opus|Reject|Transcoding still happens between G729A and Opus|

+ **Ptime(ms)**: This value determines the length of time each box (RTP packet) can hold. A higher ptime means each packet carries a longer chunk of audio/video data (bigger box), while a lower ptime means shorter chunks (smaller boxes).

https://bani-redial--connexcs-docs.netlify.app/customer/routing/#media

# 3. ConneXML : Dial > timeout 

|`timeout`|timeout in <Dial> lets you specify the maximum waiting time in seconds for the dialed party to answer|


5. **timeout**
        ```xml
        <?xml version="1.0" encoding="UTF-8"?>
        <Response>
            <Dial timeout="60">123456</Dial>
        </Response>
        ```
  https://bani-redial--connexcs-docs.netlify.app/class5/connexml/#dial